### PR TITLE
Comentando código de importação de CSS que está provavelmente causand…

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;500;700&display=swap");
+/* @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;500;700&display=swap"); */
 
 * {
   margin: 0;


### PR DESCRIPTION
Importação de fonts da google no arquivo de estilos global provavelmente é o que está causando o problema das meta tags 
Issue do Github: https://github.com/gatsbyjs/gatsby/issues/9979 